### PR TITLE
Gaining access back to ageofmakers.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-ageofmakers.com
+


### PR DESCRIPTION
Hi there,

I'm the main open-source developer for the Age of Makers game, and would need to gain back access to the ageofmakers.com CNAME domain to host the real Github Pages content.

It is a open-sourced game for educators and youth around the world, so thanks in advance for your help giving that back to teachers.

Kim.